### PR TITLE
Align cards on mobile

### DIFF
--- a/pages/repos/[language].tsx
+++ b/pages/repos/[language].tsx
@@ -70,7 +70,7 @@ const Language = ({ page, repos, languageName }: Props) => {
             </div>
           </div>
           <Sort languageName={languageName} page={page} />
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <div className="sm:grid sm:grid-cols-1 sm:gap-4 md:grid-cols-2 lg:grid-cols-3 flex items-center justify-center">
             {repos.items.map((repo: any) => (
               <Card key={repo.id} repo={repo} />
             ))}


### PR DESCRIPTION
On mobile, the cards showed up like so:

![3F512395-CC2B-4B94-829F-DA1DB89FD360](https://user-images.githubusercontent.com/47185402/135873396-3083f942-97c9-499a-919c-7eebc5d5417a.jpeg)

To make things look cleaner, I think it would be best to make these aligned in the center.

I did so by adding `flex items-center justify-center`.