### PR TITLE
ignore query param's for end date ,if it is lesser than start date

### DIFF
--- a/components/StarsFilter.tsx
+++ b/components/StarsFilter.tsx
@@ -9,14 +9,16 @@ interface FormValues {
 
 export default function StarsFilter() {
   const router = useRouter();
-  const { register, handleSubmit } = useForm<FormValues>();
+  const { register, handleSubmit, reset } = useForm<FormValues>();
   const onSubmit: SubmitHandler<FormValues> = ({ startStars, endStars }) => {
-    const query = endStars
+    const query = endStars > startStars
       ? {
           startStars,
           endStars,
         }
       : { startStars };
+      if(endStars < startStars) 
+        reset({ startStars})
     router.push({ query: { ...router.query, ...query } });
   };
 


### PR DESCRIPTION
This commit will prevent rendering of unwanted 404 page when end date given in the input box is lesser than start date 

![image](https://user-images.githubusercontent.com/52914487/137173090-2280c91c-7595-4996-ac6a-006c734f1528.png)
Eg :   startDate : 7 , endDate : 3
on click of search url will be changed to `/repos/javascript?startStars=7` instead of `/repos/javascript?startStars=7&endStars=3` which throws 404 page at you
