### PR TITLE
Remove duplicate Rust language entry

### DIFF
--- a/assets/languages.json
+++ b/assets/languages.json
@@ -21,7 +21,6 @@
     "Ruby",
     "CSharp",
     "Shell",
-    "Rust",
     "MATLAB",
     "Bash",
     "Scss",


### PR DESCRIPTION
Fixes the following browser warning:

Warning: Encountered two children with the same key, `Rust`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
