### PR TITLE
Fix the project description visibility issue

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -37,7 +37,7 @@ function Card({ repo }: Props) {
             </h2>
           </div>
 
-          <h6 className="my-5 text-lg">{emojify(repo.description)}</h6>
+          <h6 className="my-5 text-lg text-slate-50">{emojify(repo.description)}</h6>
 
           <div className="card-actions gap-y-3">
             {repo.topics.map((topic: string) => (


### PR DESCRIPTION
# What does this PR do?
This PR fixes the issue #166 of paragraph visibility in the repository card. The paragraph was not visible because of the default black color. To solve this problem, I added a tailwind class bg-slate-50 to the h6 (description) element that changes the text color to light gray. This makes the paragraph readable and improves the contrast with the background. You can see the difference in the screenshots below.

## Before
![image](https://github.com/max-programming/hacktoberfest-projects/assets/105800354/db241d1d-532f-4d4b-b5e7-87462ad4168b)

## After
![image](https://github.com/max-programming/hacktoberfest-projects/assets/105800354/f050e80a-4dda-47ae-bbe5-bb9dfc0d3d48)

