### PR TITLE
fix unreadable font on light theme

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -37,7 +37,7 @@ function Card({ repo }: Props) {
             </h2>
           </div>
 
-          <h6 className="my-5 text-lg">{emojify(repo.description)}</h6>
+          <h6 className="my-5 text-lg text-white">{emojify(repo.description)}</h6>
 
           <div className="card-actions gap-y-3">
             {repo.topics.map((topic: string) => (


### PR DESCRIPTION
Hi! Awesome page.

When browsing in light mode OS settings card text is black on black:

![Screenshot 2023-10-05 at 23 12 31](https://github.com/max-programming/hacktoberfest-projects/assets/2291045/0ca2adea-f800-46fa-afef-b5cc14a0854d)

after this fix:

![Screenshot 2023-10-05 at 23 12 21](https://github.com/max-programming/hacktoberfest-projects/assets/2291045/665e7fc2-ac17-44f0-b692-5362823669ed)
