### PR TITLE
style: align the contributor card layout

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -37,7 +37,9 @@ function Card({ repo }: Props) {
             </h2>
           </div>
 
-          <h6 className="my-5 text-2023-manga-2 text-lg">{emojify(repo.description)}</h6>
+          <h6 className="my-5 text-2023-manga-2 text-lg">
+            {emojify(repo.description)}
+          </h6>
 
           <div className="card-actions gap-y-3">
             {repo.topics.map((topic: string) => (
@@ -86,7 +88,9 @@ function Card({ repo }: Props) {
           >
             <GoRepoForked className="text-yellow-200 text-2xl" />
             <div className="flex flex-col">
-              <div className="text-lg xl:text-2xl font-semibold mb-0.5">{repo.forks}</div>
+              <div className="text-lg xl:text-2xl font-semibold mb-0.5">
+                {repo.forks}
+              </div>
               <div className="text-neutral-300 text-xs lg:text-sm">Forks</div>
             </div>
             <div

--- a/components/ContributorCard.tsx
+++ b/components/ContributorCard.tsx
@@ -31,7 +31,7 @@ export default function ContributorCard({ contributor }: Props) {
         target="_blank"
         rel="noreferrer"
       >
-        <figure className="px-10 pt-10">
+        <figure className="px-10 pt-10 h-[351px] md:h-[336px] lg:h-[204px] xl:h-[268px]">
           <img src={url} alt={contributor.name} className="rounded-xl" />
         </figure>
       </a>
@@ -43,9 +43,9 @@ export default function ContributorCard({ contributor }: Props) {
         >
           {contributor.profile}
         </a>
-        <div className="justify-center card-actions">
+        <div className="justify-center card-actions mt-auto">
           <a
-            className="text-white btn border-[#dbe8d9] hover:border-[#dbe8d9] btn-outline border-2 hover:bg-[#dbe8d9]"
+            className="text-white btn border-[#dbe8d9] hover:border-[#dbe8d9] btn-outline border-2 hover:bg-[#dbe8d9] hover:text-slate-900"
             href={`https://github.com/${contributor.login}`}
             target="_blank"
             rel="noreferrer"

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -38,7 +38,7 @@ function Hero() {
               />
               <button
                 type="submit"
-                className="btn btn-square rounded-tl-none rounded-bl-none bg-transparent border-2023-manga-3 hover:bg-2023-manga-2 hover:text-2023-void-2 hover:border-2023-manga-2"
+                className="group btn btn-square rounded-tl-none rounded-bl-none bg-transparent border-2023-manga-3 hover:bg-2023-manga-2 hover:text-2023-void-2 hover:border-2023-manga-2"
               >
                 <SearchIcon />
               </button>
@@ -84,7 +84,7 @@ function Hero() {
 
 const SearchIcon = () => (
   <svg
-    className="w-6 h-6"
+    className="w-6 h-6 group-hover:stroke-2023-bavarian-gold-3"
     fill="none"
     stroke="white"
     viewBox="0 0 24 24"


### PR DESCRIPTION
I've made some changes to `ContributorCard` towards resolving issue #177.

My suggestion:

```diff
- <figure className="px-10 pt-10">
+ <figure className="px-10 pt-10 h-[351px] md:h-[336px] lg:h-[204px] xl:h-[268px]">
```

```diff
- <div className="justify-center card-actions">
+ <div className="justify-center card-actions mt-auto">
```

While enhancing the contributor card layout, I observed that the anchor tag lacked a distinct hover state text color.
As a solution, I've introduced a new utility class:

```diff
+ hover:text-slate-900
```

Screenshot for reference:

![Contributor Card Layout Fix](https://github.com/max-programming/hacktoberfest-projects/assets/64539836/29aeb0df-4752-4dea-ab8d-321521913d95)