### PR TITLE
Select cant go back to best match

### DIFF
--- a/components/Sort.tsx
+++ b/components/Sort.tsx
@@ -107,11 +107,18 @@ export default function Sort() {
         </Button>
         <div className="h-64 p-2 z-50 overflow-y-scroll shadow dropdown-content bg-base-100 rounded-box w-60">
           <ul tabIndex={0} className="menu menu-vertical">
-            {navigationItems.map((item, index) => (
-              <li key={index}>
-                <Link href={{ query: item.href.query }}>{item.name}</Link>
-              </li>
-            ))}
+            {navigationItems.map((item, index) => {
+              const query = item.href.query;
+              if (item.name === SortTypes.BestMatch) {
+                delete query.o;
+                delete query.s;
+              }
+              return (
+                <li key={index}>
+                  <Link href={{ query }}>{item.name}</Link>
+                </li>
+              );
+            })}
           </ul>
         </div>
       </div>


### PR DESCRIPTION
I noticed that the sort dropdown could not go back to "best match" after you have selected something else. 

Appears to be because best match uses 
```ts
    {
      name: 'Best match',
      href: { query: { ...router.query } }
    },
```

So it will just keep the queries that are currently there.

The fix is to delete these when generating the link component. Not sure if there is a better way to delete them in NextJs, without removing them all together (which would delete search ones too). Setting to null leaves these in the url `&s=&o=`. 

Other option would be to make it so is sets the query params as "best" and sort as "desc".